### PR TITLE
Text wrap border addition

### DIFF
--- a/SPFD5408_Adafruit_GFX.cpp
+++ b/SPFD5408_Adafruit_GFX.cpp
@@ -59,6 +59,9 @@ Adafruit_GFX::Adafruit_GFX(int16_t w, int16_t h):
   cursor_y  = cursor_x    = 0;
   textsize  = 1;
   textcolor = textbgcolor = 0xFFFF;
+  // *** Mark42XLII change - begin
+  wrapBorder = 0;
+  // *** Mark42XLII change - end
   wrap      = true;
   _cp437    = false;
 }
@@ -430,7 +433,9 @@ void Adafruit_GFX::write(uint8_t c) {
     cursor_x += textsize*6;
     if (wrap && (cursor_x > (_width - textsize*6))) {
       cursor_y += textsize*8;
-      cursor_x = 0;
+	  // *** Mark42XLII change - begin
+      cursor_x = wrapBorder;
+	  // *** Mark42XLII change - end
     }
   }
 #if ARDUINO >= 100
@@ -506,6 +511,12 @@ void Adafruit_GFX::setTextColor(uint16_t c, uint16_t b) {
 void Adafruit_GFX::setTextWrap(boolean w) {
   wrap = w;
 }
+
+// Kedei LCD change - begin
+void Adafruit_GFX::setTextWrapBorder(uint16_t size){
+	wrapBorder = size;
+}
+//Kedei LCD change - end
 
 uint8_t Adafruit_GFX::getRotation(void) const {
   return rotation;

--- a/SPFD5408_Adafruit_GFX.h
+++ b/SPFD5408_Adafruit_GFX.h
@@ -60,8 +60,11 @@ class Adafruit_GFX : public Print {
     setTextSize(uint8_t s),
     setTextWrap(boolean w),
     setRotation(uint8_t r),
-    cp437(boolean x=true);
-
+    cp437(boolean x=true),
+	// *** Mark42XLII change - begin
+	setTextWrapBorder(uint16_t size);
+	// *** Mark42XLII change - end
+	
 #if ARDUINO >= 100
   virtual size_t write(uint8_t);
 #else
@@ -84,6 +87,9 @@ class Adafruit_GFX : public Print {
     _width, _height, // Display w/h as modified by current rotation
     cursor_x, cursor_y;
   uint16_t
+	// *** Mark42XLII change - begin
+  	wrapBorder,
+	// *** Mark42XLII change - end
     textcolor, textbgcolor;
   uint8_t
     textsize,


### PR DESCRIPTION
When using the option to set text wrap, usually it begins the next line in the corner of the screen. This function enables the ability to set a border when wrapping. Usage example in https://github.com/Mark42XLII/calculino.